### PR TITLE
Weak-link with the VideoToolbox framework

### DIFF
--- a/bowser-ios/Bowser.xcodeproj/project.pbxproj
+++ b/bowser-ios/Bowser.xcodeproj/project.pbxproj
@@ -4188,6 +4188,10 @@
 					"$(SRCROOT)/../../openwebrtc/openwebrtc-deps-armv7-ios/lib/**",
 					"$(SRCROOT)/../../openwebrtc/out/arm-apple-darwin10/lib/**",
 				);
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					VideoToolbox,
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				"PROVISIONING_PROFILE[sdk=iphoneos*]" = "";
@@ -4217,6 +4221,10 @@
 					"$(SRCROOT)",
 					"$(SRCROOT)/../../openwebrtc/openwebrtc-deps-armv7-ios/lib/**",
 					"$(SRCROOT)/../../openwebrtc/out/arm-apple-darwin10/lib/**",
+				);
+				OTHER_LDFLAGS = (
+					"-weak_framework",
+					VideoToolbox,
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";


### PR DESCRIPTION
This way we will get hardware codecs on iOS8+ but still can
run on devices using an older version of iOS.
