### PR TITLE
Disable Bitcode and allow HTTP

### DIFF
--- a/bowser-ios/Bowser.xcodeproj/project.pbxproj
+++ b/bowser-ios/Bowser.xcodeproj/project.pbxproj
@@ -440,6 +440,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Bowser/Bowser-Prefix.pch";
 				HEADER_SEARCH_PATHS = "$(inherited)";
@@ -474,6 +475,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				ENABLE_BITCODE = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Bowser/Bowser-Prefix.pch";
 				HEADER_SEARCH_PATHS = "$(inherited)";

--- a/bowser-ios/Bowser/Bowser-Info.plist
+++ b/bowser-ios/Bowser/Bowser-Info.plist
@@ -73,5 +73,10 @@
 	</array>
 	<key>User</key>
 	<string>${USER}</string>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <true/>
+    </dict>
 </dict>
 </plist>


### PR DESCRIPTION
Both needed when building using the iOS 9 SDK.